### PR TITLE
Setup callbacks before initializing 3D Graphics

### DIFF
--- a/src/HGamer3D.hs
+++ b/src/HGamer3D.hs
@@ -91,12 +91,6 @@ runGame conf glf loopSleepTime = do
     let hg3d = HG3D ols cbs varExit
 
     forkIO $ do
-        -- create graphics system
-        eG3D <- newE hg3d [
-            ctGraphics3DConfig #: conf,
-            ctGraphics3DCommand #: NoCmd
-            ]
-
         ere <- newE hg3d [
             ctExitRequestedEvent #: ()
             ]
@@ -105,6 +99,12 @@ runGame conf glf loopSleepTime = do
         forkIO $ do
             registerReceiverCBS cbs ere ctExitRequestedEvent (\_ -> writeVar varExit True >> return ())
             forever $ (stepCBS cbs)
+
+        -- create graphics system
+        eG3D <- newE hg3d [
+            ctGraphics3DConfig #: conf,
+            ctGraphics3DCommand #: NoCmd
+            ]
 
         -- create game logic loop
         forkIO $ glf hg3d


### PR DESCRIPTION
thank you for implementing #17 - I can get window resizes after the program starts.

However, as I use a tiling window manager, it actually resizes the window immediately upon opening, and I am not picking up this initial resize event.  Urho3D gets the resize and displays it in the debug output, but HGamer3D doesn't.   I believe there's a race condition in runGame between creating a new ctGraphics3DConfig and the separate thread that sets up event callbacks.  

I tried to fix this, but I am not skilled enough to modify HGamer3D (well, I modified it, but I don't know how to run it). I changed stack.yaml to look at a local source directory for HGamer3D and it compiled, but I'm unsure how to actually get aio to run it; I used an "aio local http://www.hgamer3d.org/tools/HGamer3D.0218 .stack-work/install/x86_64-linux/lts-8.20/8.0.2/lib/x86_64-linux-ghc-8.0.2/HGamer3D-0.9.5-7RbdJFjCI8H2pcsIdcYSOh" (the directory with  and probably did wrong.  However, aio run simply exits now with no message (same as before setting up aio local).

The intent is to capture initial window resize events from a tiling
window manager. Otherwise there is no way to find the initial window size.
Samples presume 800x600, which works in a non-tiling window manager.

To actually work, this probably needs a delay or some kind of synchronization
between threads. This initial patch is an attempt to just figure out how
to build HGamer3D and call the modified version, and see if changing the
order of initialization breaks anything.

Another solution would be to expose an API to get the window size,
so the application can request it on demand, instead of assuming
the initial window size matches the requested window size.